### PR TITLE
boot-*.cmd: Don't drop rootwait

### DIFF
--- a/board/lima/boot-cubieboard2.cmd
+++ b/board/lima/boot-cubieboard2.cmd
@@ -2,8 +2,8 @@ setenv fdt_high ffffffff
 setenv bootargs console=tty1 console=ttyS0,115200 rootwait
 
 # leave only one of the below uncommented, for either mmc or nfs root filesystem.
-setenv bootargs root=/dev/mmcblk0p2
-#setenv bootargs ip=dhcp root=/dev/nfs rw nfsroot=<SERVER.IP.HERE>:</EXPORTED/DIR/HERE>,nolock,tcp,nfsvers=4
+setenv bootargs $bootargs root=/dev/mmcblk0p2
+#setenv bootargs $bootargs ip=dhcp root=/dev/nfs rw nfsroot=<SERVER.IP.HERE>:</EXPORTED/DIR/HERE>,nolock,tcp,nfsvers=4
 
 # comment this for native resolution. may cause bugs in lima
 setenv bootargs $bootargs drm_kms_helper.edid_firmware=edid/1024x768.bin

--- a/board/lima/boot-nanopi-m1.cmd
+++ b/board/lima/boot-nanopi-m1.cmd
@@ -3,8 +3,8 @@ setenv fdt_high ffffffff
 setenv bootargs console=tty1 console=ttyS0,115200 rootwait
 
 # leave only one of the below uncommented, for either mmc or nfs root filesystem.
-setenv bootargs root=/dev/mmcblk0p2
-#setenv bootargs ip=dhcp root=/dev/nfs rw nfsroot=<SERVER.IP.HERE>:</EXPORTED/DIR/HERE>,nolock,tcp,nfsvers=4
+setenv bootargs $bootargs root=/dev/mmcblk0p2
+#setenv bootargs $bootargs ip=dhcp root=/dev/nfs rw nfsroot=<SERVER.IP.HERE>:</EXPORTED/DIR/HERE>,nolock,tcp,nfsvers=4
 
 # comment this for native resolution. may cause bugs in lima
 setenv bootargs $bootargs drm_kms_helper.edid_firmware=edid/1024x768.bin


### PR DESCRIPTION
Fixes panic on boot because SD card wasn't ready.

Signed-off-by: Stefan Schake <stschake@gmail.com>